### PR TITLE
Remove alist_process_nead_efz as it's useless when HleForwardTask always returns 0

### DIFF
--- a/src/alist_nead.c
+++ b/src/alist_nead.c
@@ -543,14 +543,3 @@ void alist_process_nead_mats(struct hle_t* hle)
         rsp_break(hle, SP_STATUS_TASKDONE);
     }
 }
-
-void alist_process_nead_efz(struct hle_t* hle)
-{
-    /* FIXME: implement proper ucode
-     * Forward the task if possible,
-     * otherwise use FZero ucode which should be very similar
-     */
-    if (HleForwardTask(hle->user_defined) != 0) {
-        alist_process_nead_fz(hle);
-    }
-}

--- a/src/hle.c
+++ b/src/hle.c
@@ -228,7 +228,7 @@ static bool try_fast_audio_dispatching(struct hle_t* hle)
             case 0x1f701238: /* Mario Artist Talent Studio */
                 alist_process_nead_mats(hle); return true;
             case 0x1f4c1230: /* FZeroX Expansion */
-                alist_process_nead_efz(hle); return true;
+                alist_process_nead_fz(hle); return true;
             default:
                 HleWarnMessage(hle->user_defined, "ABI2 identification regression: v=%08x", v);
             }

--- a/src/ucodes.h
+++ b/src/ucodes.h
@@ -127,7 +127,6 @@ void alist_process_nead_mm  (struct hle_t* hle);
 void alist_process_nead_mmb (struct hle_t* hle);
 void alist_process_nead_ac  (struct hle_t* hle);
 void alist_process_nead_mats(struct hle_t* hle);
-void alist_process_nead_efz (struct hle_t* hle);
 
 /* mp3 ucode */
 void mp3_task(struct hle_t* hle, unsigned int index, uint32_t address);


### PR DESCRIPTION
This prevented the F-Zero X expansion cartridge hack from booting. Normally it would fall back to LLE, but that's not supported here, and using the F-Zero X microcode is the right thing to do.